### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -7,6 +7,9 @@ on:
     tags:
       - '*'  # Trigger on tags like v1.0.0, v2.3.4
 
+permissions:
+  contents: read
+
 jobs:
   build_and_push:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/slate63/dolla/security/code-scanning/1](https://github.com/slate63/dolla/security/code-scanning/1)

To fix the issue, add a `permissions` block to the workflow. Since the workflow primarily interacts with the repository contents and does not require write access to other resources, the permissions can be limited to `contents: read`. This ensures the `GITHUB_TOKEN` has minimal access while allowing the workflow to function correctly.

The `permissions` block should be added at the root level of the workflow file to apply to all jobs. Alternatively, it can be added specifically to the `build_and_push` job if future jobs might require different permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
